### PR TITLE
pre and post daemon activities removed from spec

### DIFF
--- a/META
+++ b/META
@@ -6,4 +6,4 @@
   Meta:		1
   Name:		cerebro
   Version:	1.21
-  Release:	7
+  Release:	8

--- a/META
+++ b/META
@@ -5,5 +5,5 @@
 ##
   Meta:		1
   Name:		cerebro
-  Version:	1.18
-  Release:	1
+  Version:	1.21
+  Release:	7

--- a/cerebro.spec.in
+++ b/cerebro.spec.in
@@ -6,28 +6,38 @@ Summary: Cerebro cluster monitoring tools and libraries
 Group: System Environment/Base
 License: GPL
 Source: @PROJECT@-@VERSION@.tar.gz
-BuildRoot: %{_tmppath}/@PROJECT@-@VERSION@
 
 BuildRequires: systemd
 Requires: systemd
 Requires: /bin/sh 
 
+%define _with_gendersllnl                  --with-gendersllnl
+%define _without_gendersllnl_ion           --without-gendersllnl-ion
+%define _without_genders                   --without-genders
+%define _without_hostsfile                 --without-hostsfile
+%define _with_boottime                     --with-boottime
+%define _without_loadavg                   --without-loadavg
+%define _without_memory                    --without-memory
+%define _without_network                   --without-network
+%define _without_slurm_state               --without-slurm-state
+%define _with_shutdown                     --with-shutdown
+%define _with_updown                       --with-updown
+%define _without_bgl_ciod                  --without-bgl-ciod
+
 %description
 Cerebro is a collection of cluster monitoring tools and libraries.
-
-%{!?_with_genders: %{!?_without_genders: %define _without_genders --without-genders}}
-%{!?_with_hostsfile: %{!?_without_hostsfile: %define _with_hostsfile --with-hostsfile}}
-%{!?_with_boottime: %{!?_without_boottime: %define _with_boottime --with-boottime}}
-%{!?_with_loadavg: %{!?_without_loadavg: %define _with_loadavg --with-loadavg}}
-%{!?_with_memory: %{!?_without_memory: %define _with_memory --with-memory}}
-%{!?_with_network: %{!?_without_network: %define _with_network --with-network}}
-%{!?_with_slurm_state: %{!?_without_slurm_state: %define _without_slurm_state --without-slurm-state}}
-%{!?_with_shutdown: %{!?_without_shutdown: %define _without_shutdown --without-shutdown}}
-%{!?_with_updown: %{!?_without_updown: %define _with_updown --with-updown}}
 
 %if %{?_with_debug:1}%{!?_with_debug:0}
 %define _enable_debug --enable-debug
 %endif
+
+%package clusterlist-gendersllnl
+Summary: clusterlist gendersllnl module
+Group: System Environment/Base
+Requires: cerebro
+Requires: gendersllnl
+%description clusterlist-gendersllnl
+Gendersllnl module
 
 %package clusterlist-genders
 Summary: clusterlist genders module
@@ -98,6 +108,10 @@ Event module to monitor node up/down.
 
 %build
 %configure --program-prefix=%{?_program_prefix:%{_program_prefix}} \
+           %{?_with_gendersllnl} \
+           %{?_without_gendersllnl} \
+           %{?_with_gendersllnl_ion} \
+           %{?_without_gendersllnl_ion} \
            %{?_with_genders} \
            %{?_without_genders} \
            %{?_with_hostsfile} \

--- a/cerebro.spec.in
+++ b/cerebro.spec.in
@@ -126,13 +126,6 @@ Event module to monitor node up/down.
            --with-systemdsystemunitdir=%{_unitdir}
 make 
 
-%pretrans
-# stop cerebro before modification, remember if it was running
-if systemctl status cerebrod | grep running; then
-        touch %{_tmppath}/cerebrod_restart_sentinel_file
-        systemctl stop cerebrod
-fi
-
 %install
 rm -rf $RPM_BUILD_ROOT
 DESTDIR="$RPM_BUILD_ROOT" make install
@@ -217,12 +210,3 @@ DESTDIR="$RPM_BUILD_ROOT" make install
 %defattr(700,root,root)
 %{_libdir}/cerebro/*cerebro_event_updown.*
 %endif
-
-%posttrans
-# do we need to restart it?
-if [ -f %{_tmppath}/cerebrod_restart_sentinel_file ]; then
-        systemctl daemon-reload
-        systemctl enable cerebrod
-        systemctl start cerebrod
-        rm %{_tmppath}/cerebrod_restart_sentinel_file
-fi

--- a/cerebro.spec.in
+++ b/cerebro.spec.in
@@ -140,6 +140,12 @@ Event module to monitor node up/down.
            --with-systemdsystemunitdir=%{_unitdir}
 make 
 
+%post
+# are we upgrading? restart it if running
+if [[ "$1" -gt 1 ]]; then
+	systemctl try-restart cerebrod
+fi
+
 %install
 rm -rf $RPM_BUILD_ROOT
 DESTDIR="$RPM_BUILD_ROOT" make install

--- a/config/ac_gendersllnl_ion.m4
+++ b/config/ac_gendersllnl_ion.m4
@@ -1,0 +1,41 @@
+##*****************************************************************************
+## $Id: ac_gendersllnl_ion.m4,v 1.7 2005/05/10 22:39:40 achu Exp $
+##*****************************************************************************
+
+AC_DEFUN([AC_GENDERSLLNL_ION],
+[
+  AC_MSG_CHECKING([for whether to build gendersllnl-ion modules])
+  AC_ARG_WITH([gendersllnl-ion],
+    AC_HELP_STRING([--with-gendersllnl-ion], [Build gendersllnl-ion modules]),
+    [ case "$withval" in
+        no)  ac_gendersllnl_ion_test=no ;;
+        yes) ac_gendersllnl_ion_test=yes ;;
+        *)   AC_MSG_ERROR([bad value "$withval" for --with-gendersllnl-ion]) ;;
+      esac
+    ]
+  )
+  AC_MSG_RESULT([${ac_gendersllnl_ion_test=yes}])
+  
+  if test "$ac_gendersllnl_ion_test" = "yes"; then
+     AC_CHECK_LIB([gendersllnl], [genders_isnode_or_altnode], [ac_have_gendersllnl_ion=yes], [])
+  fi
+
+  if test "$ac_have_gendersllnl_ion" = "yes"; then
+     AC_DEFINE([WITH_GENDERSLLNL_ION], [1], [Define if you have gendersllnl.])
+     GENDERSLLNL_ION_LIBS="-lgendersllnl"
+     MANPAGE_GENDERSLLNL_ION=1
+     ac_with_gendersllnl_ion=yes
+   
+     AC_CHECK_LIB(genders,
+                  genders_index_attrvals,
+                  AC_DEFINE(HAVE_GENDERS_INDEX_ATTRVALS, [1],
+                            [define genders_index_attrvals exists]),
+                  [])
+  else
+     MANPAGE_GENDERSLLNL_ION=0
+     ac_with_gendersllnl_ion=no
+  fi
+
+  AC_SUBST(GENDERSLLNL_ION_LIBS)
+  AC_SUBST(MANPAGE_GENDERSLLNL_ION)
+])

--- a/man/cerebro-admin.8.in
+++ b/man/cerebro-admin.8.in
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro-admin.8.in,v 1.10 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro-stat.8.in
+++ b/man/cerebro-stat.8.in
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro-stat.8.in,v 1.13 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro.7.in
+++ b/man/cerebro.7.in
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro.7,v 1.2 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro.conf.5.in
+++ b/man/cerebro.conf.5.in
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro.conf.5.in,v 1.37 2010-06-01 21:01:40 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_errnum.3
+++ b/man/cerebro_errnum.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_errnum.3,v 1.11 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_event.3
+++ b/man/cerebro_event.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_event.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_event_parse.3
+++ b/man/cerebro_event_parse.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_event_parse.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_event_register.3
+++ b/man/cerebro_event_register.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_event_register.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_event_unregister.3
+++ b/man/cerebro_event_unregister.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_event_unregister.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_flush_metric.3
+++ b/man/cerebro_flush_metric.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_flush_metric.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_get_event_names.3
+++ b/man/cerebro_get_event_names.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_get_event_names.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_get_flags.3
+++ b/man/cerebro_get_flags.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_get_flags.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_get_hostname.3
+++ b/man/cerebro_get_hostname.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_get_hostname.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_get_metric_data.3
+++ b/man/cerebro_get_metric_data.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_get_metric_data.3,v 1.17 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_get_metric_names.3
+++ b/man/cerebro_get_metric_names.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_get_metric_names.3,v 1.9 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_get_port.3
+++ b/man/cerebro_get_port.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_get_port.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_get_timeout_len.3
+++ b/man/cerebro_get_timeout_len.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_get_timeout_len.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_handle_create.3
+++ b/man/cerebro_handle_create.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_handle_create.3,v 1.8 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_handle_destroy.3
+++ b/man/cerebro_handle_destroy.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_handle_destroy.3,v 1.11 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_module.3.in
+++ b/man/cerebro_module.3.in
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_module.3.in,v 1.25 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_module_devel.3.in
+++ b/man/cerebro_module_devel.3.in
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_module_devel.3.in,v 1.31 2010-02-04 23:50:50 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_namelist_destroy.3
+++ b/man/cerebro_namelist_destroy.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_namelist_destroy.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_namelist_errnum.3
+++ b/man/cerebro_namelist_errnum.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_namelist_errnum.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_namelist_iterator_at_end.3
+++ b/man/cerebro_namelist_iterator_at_end.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_namelist_iterator_at_end.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_namelist_iterator_create.3
+++ b/man/cerebro_namelist_iterator_create.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_namelist_iterator_create.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_namelist_iterator_destroy.3
+++ b/man/cerebro_namelist_iterator_destroy.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_namelist_iterator_destroy.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_namelist_iterator_errnum.3
+++ b/man/cerebro_namelist_iterator_errnum.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_namelist_iterator_errnum.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_namelist_iterator_name.3
+++ b/man/cerebro_namelist_iterator_name.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_namelist_iterator_name.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_namelist_iterator_next.3
+++ b/man/cerebro_namelist_iterator_next.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_namelist_iterator_next.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_namelist_iterator_reset.3
+++ b/man/cerebro_namelist_iterator_reset.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_namelist_iterator_reset.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_namelist_length.3
+++ b/man/cerebro_namelist_length.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_namelist_length.3,v 1.6 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_destroy.3
+++ b/man/cerebro_nodelist_destroy.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_destroy.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_errnum.3
+++ b/man/cerebro_nodelist_errnum.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_errnum.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_iterator_at_end.3
+++ b/man/cerebro_nodelist_iterator_at_end.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_iterator_at_end.3,v 1.8 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_iterator_create.3
+++ b/man/cerebro_nodelist_iterator_create.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_iterator_create.3,v 1.8 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_iterator_destroy.3
+++ b/man/cerebro_nodelist_iterator_destroy.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_iterator_destroy.3,v 1.8 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_iterator_errnum.3
+++ b/man/cerebro_nodelist_iterator_errnum.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_iterator_errnum.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_iterator_metric_value.3
+++ b/man/cerebro_nodelist_iterator_metric_value.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_iterator_metric_value.3,v 1.8 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_iterator_next.3
+++ b/man/cerebro_nodelist_iterator_next.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_iterator_next.3,v 1.8 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_iterator_nodename.3
+++ b/man/cerebro_nodelist_iterator_nodename.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_iterator_nodename.3,v 1.8 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_iterator_reset.3
+++ b/man/cerebro_nodelist_iterator_reset.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_iterator_reset.3,v 1.8 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_length.3
+++ b/man/cerebro_nodelist_length.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_length.3,v 1.10 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_nodelist_metric_name.3
+++ b/man/cerebro_nodelist_metric_name.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_nodelist_metric_name.3,v 1.19 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_register_metric.3
+++ b/man/cerebro_register_metric.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_register_metric.3,v 1.10 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_resend_metric.3
+++ b/man/cerebro_resend_metric.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_resend_metric.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_set_flags.3
+++ b/man/cerebro_set_flags.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_set_flags.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_set_hostname.3
+++ b/man/cerebro_set_hostname.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_set_hostname.3,v 1.16 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_set_port.3
+++ b/man/cerebro_set_port.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_set_port.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_set_timeout_len.3
+++ b/man/cerebro_set_timeout_len.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_set_timeout_len.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_strerror.3
+++ b/man/cerebro_strerror.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_strerror.3,v 1.8 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_unregister_metric.3
+++ b/man/cerebro_unregister_metric.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_unregister_metric.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebro_update_metric_value.3
+++ b/man/cerebro_update_metric_value.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebro_update_metric_value.3,v 1.7 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/cerebrod.8.in
+++ b/man/cerebrod.8.in
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: cerebrod.8.in,v 1.26 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/man/libcerebro.3
+++ b/man/libcerebro.3
@@ -1,7 +1,7 @@
 .\"#############################################################################
 .\"$Id: libcerebro.3,v 1.27 2010-02-02 01:01:20 chu11 Exp $
 .\"#############################################################################
-.\"  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+.\"  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
 .\"  Copyright (C) 2005-2007 The Regents of the University of California.
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebro-admin/cerebro-admin.c
+++ b/src/cerebro-admin/cerebro-admin.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro-admin.c,v 1.19 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebro-stat/cerebro-stat.c
+++ b/src/cerebro-stat/cerebro-stat.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $id: cerebro-stat.c,v 1.18 2005/07/26 22:30:56 achu Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod.c
+++ b/src/cerebrod/cerebrod.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod.c,v 1.89 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod.h
+++ b/src/cerebrod/cerebrod.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod.h,v 1.15 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_config.c
+++ b/src/cerebrod/cerebrod_config.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_config.c,v 1.146 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_config.h
+++ b/src/cerebrod/cerebrod_config.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_config.h,v 1.73 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_daemon.c
+++ b/src/cerebrod/cerebrod_daemon.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_daemon.c,v 1.15 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_daemon.h
+++ b/src/cerebrod/cerebrod_daemon.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_daemon.h,v 1.9 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_debug.h
+++ b/src/cerebrod/cerebrod_debug.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: debug.h,v 1.12 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_event_node_timeout_monitor.c
+++ b/src/cerebrod/cerebrod_event_node_timeout_monitor.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_event_node_timeout_monitor.c,v 1.11 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_event_node_timeout_monitor.h
+++ b/src/cerebrod/cerebrod_event_node_timeout_monitor.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_event_node_timeout_monitor.h,v 1.7 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_event_server.c
+++ b/src/cerebrod/cerebrod_event_server.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_event_server.c,v 1.16 2010-04-06 22:10:11 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_event_server.h
+++ b/src/cerebrod/cerebrod_event_server.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_event_server.h,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_event_update.c
+++ b/src/cerebrod/cerebrod_event_update.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_event_update.c,v 1.15 2010-04-06 22:10:11 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_event_update.h
+++ b/src/cerebrod/cerebrod_event_update.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_event_update.h,v 1.11 2010-04-06 22:10:11 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_listener.c
+++ b/src/cerebrod/cerebrod_listener.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_listener.c,v 1.150 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_listener.h
+++ b/src/cerebrod/cerebrod_listener.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_listener.h,v 1.17 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_listener_data.c
+++ b/src/cerebrod/cerebrod_listener_data.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_listener_data.c,v 1.62 2010-04-06 22:10:11 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_listener_data.h
+++ b/src/cerebrod/cerebrod_listener_data.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_listener_data.h,v 1.18 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_message.c
+++ b/src/cerebrod/cerebrod_message.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_message.c,v 1.6 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_message.h
+++ b/src/cerebrod/cerebrod_message.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_message.h,v 1.6 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_metric_controller.c
+++ b/src/cerebrod/cerebrod_metric_controller.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_metric_controller.c,v 1.52 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_metric_controller.h
+++ b/src/cerebrod/cerebrod_metric_controller.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_metric_controller.h,v 1.7 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_metric_server.c
+++ b/src/cerebrod/cerebrod_metric_server.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_metric_server.c,v 1.49 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_metric_server.h
+++ b/src/cerebrod/cerebrod_metric_server.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_metric_server.h,v 1.12 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_monitor_update.c
+++ b/src/cerebrod/cerebrod_monitor_update.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_monitor_update.c,v 1.9 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_monitor_update.h
+++ b/src/cerebrod/cerebrod_monitor_update.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_monitor_update.h,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_speaker.c
+++ b/src/cerebrod/cerebrod_speaker.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_speaker.c,v 1.115 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_speaker.h
+++ b/src/cerebrod/cerebrod_speaker.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_speaker.h,v 1.15 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_speaker_data.c
+++ b/src/cerebrod/cerebrod_speaker_data.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_speaker_data.c,v 1.54 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_speaker_data.h
+++ b/src/cerebrod/cerebrod_speaker_data.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_speaker_data.h,v 1.20 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_util.c
+++ b/src/cerebrod/cerebrod_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_util.c,v 1.42 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/cerebrod/cerebrod_util.h
+++ b/src/cerebrod/cerebrod_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_util.h,v 1.20 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro.c
+++ b/src/libs/cerebro/cerebro.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro.c,v 1.19 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_api.h
+++ b/src/libs/cerebro/cerebro_api.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_api.h,v 1.17 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_config_util.c
+++ b/src/libs/cerebro/cerebro_config_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_config_util.c,v 1.14 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_config_util.h
+++ b/src/libs/cerebro/cerebro_config_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_config_util.h,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_event.c
+++ b/src/libs/cerebro/cerebro_event.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $id: cerebro_metric.c,v 1.17 2005/06/07 16:18:58 achu Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_metric_control.c
+++ b/src/libs/cerebro/cerebro_metric_control.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $id: cerebro_metric.c,v 1.17 2005/06/07 16:18:58 achu Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_metric_data.c
+++ b/src/libs/cerebro/cerebro_metric_data.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $id: cerebro_metric.c,v 1.17 2005/06/07 16:18:58 achu Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_metric_names.c
+++ b/src/libs/cerebro/cerebro_metric_names.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $id: cerebro_metric.c,v 1.17 2005/06/07 16:18:58 achu Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_metric_util.c
+++ b/src/libs/cerebro/cerebro_metric_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $id: cerebro_metric.c,v 1.17 2005/06/07 16:18:58 achu Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_metric_util.h
+++ b/src/libs/cerebro/cerebro_metric_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_util.h,v 1.17 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_namelist.c
+++ b/src/libs/cerebro/cerebro_namelist.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_namelist.c,v 1.6 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_namelist_util.c
+++ b/src/libs/cerebro/cerebro_namelist_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_namelist_util.c,v 1.6 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_namelist_util.h
+++ b/src/libs/cerebro/cerebro_namelist_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_namelist_util.h,v 1.6 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_nodelist.c
+++ b/src/libs/cerebro/cerebro_nodelist.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_nodelist.c,v 1.17 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_nodelist_util.c
+++ b/src/libs/cerebro/cerebro_nodelist_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_nodelist_util.c,v 1.15 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_nodelist_util.h
+++ b/src/libs/cerebro/cerebro_nodelist_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_nodelist_util.h,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_util.c
+++ b/src/libs/cerebro/cerebro_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_util.c,v 1.12 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro/cerebro_util.h
+++ b/src/libs/cerebro/cerebro_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_util.h,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/cerebro_error/cerebro_error.c
+++ b/src/libs/cerebro_error/cerebro_error.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_error.c,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/common/marshall.c
+++ b/src/libs/common/marshall.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: marshall.c,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/common/marshall.h
+++ b/src/libs/common/marshall.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: marshall.h,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/common/vector.c
+++ b/src/libs/common/vector.c
@@ -1,7 +1,7 @@
 /*****************************************************************************
  *  $Id: vector.c,v 1.12 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/common/vector.h
+++ b/src/libs/common/vector.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
  *  $Id: vector.h,v 1.7 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/debug/debug.c
+++ b/src/libs/debug/debug.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: debug.c,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/debug/debug.h
+++ b/src/libs/debug/debug.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: debug.h,v 1.12 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro.h
+++ b/src/libs/include/cerebro.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro.h,v 1.32 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebro_clusterlist_module.h
+++ b/src/libs/include/cerebro/cerebro_clusterlist_module.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_clusterlist_module.h,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebro_config.h
+++ b/src/libs/include/cerebro/cerebro_config.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_config.h,v 1.21 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebro_config_module.h
+++ b/src/libs/include/cerebro/cerebro_config_module.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_config_module.h,v 1.9 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebro_constants.h
+++ b/src/libs/include/cerebro/cerebro_constants.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_constants.h,v 1.16 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebro_error.h
+++ b/src/libs/include/cerebro/cerebro_error.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_error.h,v 1.7 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebro_event_module.h
+++ b/src/libs/include/cerebro/cerebro_event_module.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_event_module.h,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebro_event_protocol.h
+++ b/src/libs/include/cerebro/cerebro_event_protocol.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_event_protocol.h,v 1.8 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebro_metric_control_protocol.h.in
+++ b/src/libs/include/cerebro/cerebro_metric_control_protocol.h.in
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_control_protocol.h.in,v 1.14 2007-10-17 22:04:49 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebro_metric_module.h
+++ b/src/libs/include/cerebro/cerebro_metric_module.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_module.h,v 1.17 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebro_metric_server_protocol.h
+++ b/src/libs/include/cerebro/cerebro_metric_server_protocol.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_server_protocol.h,v 1.14 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebro_monitor_module.h
+++ b/src/libs/include/cerebro/cerebro_monitor_module.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_monitor_module.h,v 1.12 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/include/cerebro/cerebrod_message_protocol.h
+++ b/src/libs/include/cerebro/cerebrod_message_protocol.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebrod_message_protocol.h,v 1.6 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/clusterlist_module.c
+++ b/src/libs/modules/clusterlist_module.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: clusterlist_module.c,v 1.19 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/clusterlist_module.h
+++ b/src/libs/modules/clusterlist_module.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: clusterlist_module.h,v 1.10 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/config_module.c
+++ b/src/libs/modules/config_module.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: config_module.c,v 1.24 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/config_module.h
+++ b/src/libs/modules/config_module.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: config_module.h,v 1.11 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/event_module.c
+++ b/src/libs/modules/event_module.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: event_module.c,v 1.10 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/event_module.h
+++ b/src/libs/modules/event_module.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: event_module.h,v 1.9 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/metric_module.c
+++ b/src/libs/modules/metric_module.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: metric_module.c,v 1.29 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/metric_module.h
+++ b/src/libs/modules/metric_module.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: metric_module.h,v 1.18 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/module_util.c
+++ b/src/libs/modules/module_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: module_util.c,v 1.22 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/module_util.h
+++ b/src/libs/modules/module_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: module_util.h,v 1.9 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/monitor_module.c
+++ b/src/libs/modules/monitor_module.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: monitor_module.c,v 1.25 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/modules/monitor_module.h
+++ b/src/libs/modules/monitor_module.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: monitor_module.h,v 1.14 2010-02-02 01:01:20 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/util/config_util.c
+++ b/src/libs/util/config_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: config_util.c,v 1.35 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/util/config_util.h
+++ b/src/libs/util/config_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: config_util.h,v 1.8 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/util/data_util.c
+++ b/src/libs/util/data_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: data_util.c,v 1.8 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/util/data_util.h
+++ b/src/libs/util/data_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: data_util.h,v 1.7 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/util/network_util.c
+++ b/src/libs/util/network_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: network_util.c,v 1.15 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/util/network_util.h
+++ b/src/libs/util/network_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: network_util.h,v 1.8 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/wrappers/wrappers.c
+++ b/src/libs/wrappers/wrappers.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: wrappers.c,v 1.22 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/wrappers/wrappers.h
+++ b/src/libs/wrappers/wrappers.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: wrappers.h,v 1.27 2010-04-06 22:10:11 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/wrappers/wrappers_hash.c
+++ b/src/libs/wrappers/wrappers_hash.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: wrappers_hash.c,v 1.8 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/wrappers/wrappers_hostlist.c
+++ b/src/libs/wrappers/wrappers_hostlist.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: wrappers_hostlist.c,v 1.11 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/wrappers/wrappers_list.c
+++ b/src/libs/wrappers/wrappers_list.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: wrappers_list.c,v 1.8 2010-04-06 22:10:11 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/wrappers/wrappers_marshall.c
+++ b/src/libs/wrappers/wrappers_marshall.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: wrappers_marshall.c,v 1.6 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/libs/wrappers/wrappers_pthread.c
+++ b/src/libs/wrappers/wrappers_pthread.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: wrappers_pthread.c,v 1.6 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/clusterlist/cerebro_clusterlist_genders.c
+++ b/src/modules/clusterlist/cerebro_clusterlist_genders.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_clusterlist_genders.c,v 1.41 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/clusterlist/cerebro_clusterlist_genders_util.c
+++ b/src/modules/clusterlist/cerebro_clusterlist_genders_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_clusterlist_genders_util.c,v 1.28 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/clusterlist/cerebro_clusterlist_genders_util.h
+++ b/src/modules/clusterlist/cerebro_clusterlist_genders_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_clusterlist_genders_util.h,v 1.15 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/clusterlist/cerebro_clusterlist_gendersllnl.c
+++ b/src/modules/clusterlist/cerebro_clusterlist_gendersllnl.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_clusterlist_gendersllnl.c,v 1.30 2005/08/23 21:10:15 achu Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/clusterlist/cerebro_clusterlist_gendersllnl.c
+++ b/src/modules/clusterlist/cerebro_clusterlist_gendersllnl.c
@@ -1,0 +1,275 @@
+/*****************************************************************************\
+ *  $Id: cerebro_clusterlist_gendersllnl.c,v 1.30 2005/08/23 21:10:15 achu Exp $
+ *****************************************************************************
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2005-2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Albert Chu <chu11@llnl.gov>.
+ *  UCRL-CODE-155989 All rights reserved.
+ *
+ *  This file is part of Cerebro, a collection of cluster monitoring
+ *  tools and libraries.  For details, see
+ *  <http://www.llnl.gov/linux/cerebro/>.
+ *
+ *  Cerebro is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  Cerebro is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ *  details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with Cerebro.  If not, see <http://www.gnu.org/licenses/>.
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <stdio.h>
+#include <stdlib.h>
+#if STDC_HEADERS
+#include <string.h>
+#endif /* STDC_HEADERS */
+#include <errno.h>
+
+#include <gendersllnl.h>
+
+#include "cerebro/cerebro_clusterlist_module.h"
+#include "cerebro/cerebro_constants.h"
+
+#include "cerebro_clusterlist_genders_util.h"
+#include "cerebro_clusterlist_util.h"
+
+#include "debug.h"
+
+#define GENDERSLLNL_CLUSTERLIST_MODULE_NAME "gendersllnl"
+
+/*
+ * gh
+ *
+ * genders handle
+ */
+static genders_t gh = NULL;
+
+/*
+ * gendersllnl_clusterlist_interface_version
+ *
+ * gendersllnl clusterlist module interface_version function
+ */
+static int 
+gendersllnl_clusterlist_interface_version(void)
+{
+  return CEREBRO_CLUSTERLIST_INTERFACE_VERSION;
+}
+
+/*
+ * gendersllnl_clusterlist_setup
+ *
+ * gendersllnl clusterlist module setup function
+ */
+static int
+gendersllnl_clusterlist_setup(void)
+{
+  int rv;
+
+  if (gh)
+    {
+      CEREBRO_DBG(("gh non-null"));
+      return 0;
+    }
+
+  rv = cerebro_clusterlist_genders_setup(&gh, NULL);
+
+#if HAVE_GENDERS_INDEX_ATTRVALS
+  if (!rv)
+    {
+      /* This is for performance improvements if the indexing API
+       * functions are available.  Don't fail and return -1, since the
+       * rest is not dependent on this section of code.
+       */
+      genders_index_attrvals(gh, GENDERS_ALTNAME_ATTRIBUTE);
+    }
+#endif /* HAVE_GENDERS_INDEX_ATTRVALS */
+
+  return rv;
+}
+
+/*
+ * gendersllnl_clusterlist_cleanup
+ *
+ * gendersllnl clusterlist module cleanup function
+ */
+static int
+gendersllnl_clusterlist_cleanup(void)
+{
+  if (!gh)
+    return 0;
+
+  return cerebro_clusterlist_genders_cleanup(&gh);
+}
+
+/*
+ * gendersllnl_clusterlist_numnodes
+ *
+ * gendersllnl clusterlist module numnodes function
+ */
+static int
+gendersllnl_clusterlist_numnodes(void)
+{
+  if (!gh)
+    {
+      CEREBRO_DBG(("gh null"));
+      return -1;
+    }
+
+  return cerebro_clusterlist_genders_numnodes(gh);
+}
+
+/*
+ * gendersllnl_clusterlist_get_all_nodes
+ *
+ * gendersllnl clusterlist module get_all_nodes function
+ */
+static int
+gendersllnl_clusterlist_get_all_nodes(char ***nodes)
+{
+  if (!gh)
+    {
+      CEREBRO_DBG(("gh null"));
+      return -1;
+    }
+
+  if (!nodes)
+    {
+      CEREBRO_DBG(("invalid parameters"));
+      return -1;
+    }
+
+  return cerebro_clusterlist_genders_get_all_nodes(gh, nodes);
+}
+
+/*
+ * gendersllnl_clusterlist_node_in_cluster
+ *
+ * gendersllnl clusterlist module node_in_cluster function
+ */
+static int
+gendersllnl_clusterlist_node_in_cluster(const char *node)
+{
+  char nodebuf[CEREBRO_MAX_NODENAME_LEN+1];
+  char *nodePtr = NULL;
+  int flag;
+
+  if (!gh)
+    {
+      CEREBRO_DBG(("gh null"));
+      return -1;
+    }
+
+  if (!node)
+    {
+      CEREBRO_DBG(("invalid parameters"));
+      return -1;
+    }
+
+  /* Shorten hostname if necessary */
+  if (strchr(node, '.'))
+    {
+      char *p;
+
+      memset(nodebuf, '\0', CEREBRO_MAX_NODENAME_LEN+1);
+      strncpy(nodebuf, node, CEREBRO_MAX_NODENAME_LEN);
+      p = strchr(nodebuf, '.');
+      *p = '\0';
+      nodePtr = nodebuf;
+    }
+  else
+    nodePtr = (char *)node;
+
+  if ((flag = genders_isnode_or_altnode(gh, nodePtr)) < 0)
+    {
+      CEREBRO_ERR(("genders_isnode_or_altnode: %s", genders_errormsg(gh)));
+      return -1;
+    }
+  
+  return flag;
+}
+
+/*
+ * gendersllnl_clusterlist_get_nodename
+ *
+ * gendersllnl clusterlist module get_nodename function
+ */
+static int
+gendersllnl_clusterlist_get_nodename(const char *node, 
+				     char *buf, 
+				     unsigned int buflen)
+{
+  char nodebuf[CEREBRO_MAX_NODENAME_LEN+1];
+  char *nodePtr = NULL;
+  int rv;
+
+  if (!gh)
+    {
+      CEREBRO_DBG(("gh null"));
+      return -1;
+    }
+
+  if (!node || !buf || !buflen)
+    {
+      CEREBRO_DBG(("invalid parameters"));
+      return -1;
+    }
+
+  /* Shorten hostname if necessary */
+  if (strchr(node, '.'))
+    {
+      char *p;
+
+      memset(nodebuf, '\0', CEREBRO_MAX_NODENAME_LEN+1);
+      strncpy(nodebuf, node, CEREBRO_MAX_NODENAME_LEN);
+      p = strchr(nodebuf, '.');
+      *p = '\0';
+      nodePtr = nodebuf;
+    }
+  else
+    nodePtr = (char *)node;
+
+  if ((rv = gendersllnl_clusterlist_node_in_cluster(nodePtr)) < 0)
+      return -1;
+
+  if (!rv)
+    {
+      return cerebro_copy_nodename(nodePtr, buf, buflen);
+    }
+  else
+    {
+      if (genders_to_gendname(gh, nodePtr, buf, buflen) < 0)
+	{
+	  CEREBRO_ERR(("genders_to_gendname: %s", genders_errormsg(gh)));
+	  return -1;
+	}
+    }
+
+  return 0;
+}
+
+#if WITH_STATIC_MODULES
+struct cerebro_clusterlist_module_info gendersllnl_clusterlist_module_info =
+#else  /* !WITH_STATIC_MODULES */
+struct cerebro_clusterlist_module_info clusterlist_module_info =
+#endif /* !WITH_STATIC_MODULES */
+  {
+    GENDERSLLNL_CLUSTERLIST_MODULE_NAME,
+    &gendersllnl_clusterlist_interface_version,
+    &gendersllnl_clusterlist_setup,
+    &gendersllnl_clusterlist_cleanup,
+    &gendersllnl_clusterlist_numnodes,
+    &gendersllnl_clusterlist_get_all_nodes,
+    &gendersllnl_clusterlist_node_in_cluster,
+    &gendersllnl_clusterlist_get_nodename,
+  };

--- a/src/modules/clusterlist/cerebro_clusterlist_gendersllnl_ion.c
+++ b/src/modules/clusterlist/cerebro_clusterlist_gendersllnl_ion.c
@@ -1,0 +1,276 @@
+/*****************************************************************************\
+ *  $Id: cerebro_clusterlist_gendersllnl_ion.c,v 1.4 2007/02/09 00:59:20 achu Exp $
+ *****************************************************************************
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2005-2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Albert Chu <chu11@llnl.gov>.
+ *  UCRL-CODE-155989 All rights reserved.
+ *
+ *  This file is part of Cerebro, a collection of cluster monitoring
+ *  tools and libraries.  For details, see
+ *  <http://www.llnl.gov/linux/cerebro/>.
+ *
+ *  Cerebro is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  Cerebro is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ *  details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with Cerebro.  If not, see <http://www.gnu.org/licenses/>.
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <stdio.h>
+#include <stdlib.h>
+#if STDC_HEADERS
+#include <string.h>
+#endif /* STDC_HEADERS */
+#include <errno.h>
+
+#include <gendersllnl.h>
+
+#include "cerebro/cerebro_clusterlist_module.h"
+#include "cerebro/cerebro_constants.h"
+
+#include "cerebro_clusterlist_genders_util.h"
+#include "cerebro_clusterlist_util.h"
+
+#include "debug.h"
+
+#define GENDERSLLNL_ION_CLUSTERLIST_MODULE_NAME "gendersllnl_ion"
+
+#define GENDERSLLNL_ION_DATABASE "/etc/genders.ion"
+/*
+ * gh
+ *
+ * genders handle
+ */
+static genders_t gh = NULL;
+
+/*
+ * gendersllnl_ion_clusterlist_interface_version
+ *
+ * gendersllnl_ion clusterlist module interface_version function
+ */
+static int 
+gendersllnl_ion_clusterlist_interface_version(void)
+{
+  return CEREBRO_CLUSTERLIST_INTERFACE_VERSION;
+}
+
+/*
+ * gendersllnl_ion_clusterlist_setup
+ *
+ * gendersllnl_ion clusterlist module setup function
+ */
+static int
+gendersllnl_ion_clusterlist_setup(void)
+{
+  int rv;
+
+  if (gh)
+    {
+      CEREBRO_DBG(("gh non-null"));
+      return 0;
+    }
+
+  rv = cerebro_clusterlist_genders_setup(&gh, GENDERSLLNL_ION_DATABASE);
+
+#if HAVE_GENDERS_INDEX_ATTRVALS
+  if (!rv)
+    {
+      /* This is for performance improvements if the indexing API
+       * functions are available.  Don't fail and return -1, since the
+       * rest is not dependent on this section of code.
+       */
+      genders_index_attrvals(gh, GENDERS_ALTNAME_ATTRIBUTE);
+    }
+#endif /* HAVE_GENDERS_INDEX_ATTRVALS */
+
+  return rv;
+}
+
+/*
+ * gendersllnl_ion_clusterlist_cleanup
+ *
+ * gendersllnl_ion clusterlist module cleanup function
+ */
+static int
+gendersllnl_ion_clusterlist_cleanup(void)
+{
+  if (!gh)
+    return 0;
+
+  return cerebro_clusterlist_genders_cleanup(&gh);
+}
+
+/*
+ * gendersllnl_ion_clusterlist_numnodes
+ *
+ * gendersllnl_ion clusterlist module numnodes function
+ */
+static int
+gendersllnl_ion_clusterlist_numnodes(void)
+{
+  if (!gh)
+    {
+      CEREBRO_DBG(("gh null"));
+      return -1;
+    }
+
+  return cerebro_clusterlist_genders_numnodes(gh);
+}
+
+/*
+ * gendersllnl_ion_clusterlist_get_all_nodes
+ *
+ * gendersllnl_ion clusterlist module get_all_nodes function
+ */
+static int
+gendersllnl_ion_clusterlist_get_all_nodes(char ***nodes)
+{
+  if (!gh)
+    {
+      CEREBRO_DBG(("gh null"));
+      return -1;
+    }
+
+  if (!nodes)
+    {
+      CEREBRO_DBG(("invalid parameters"));
+      return -1;
+    }
+
+  return cerebro_clusterlist_genders_get_all_nodes(gh, nodes);
+}
+
+/*
+ * gendersllnl_ion_clusterlist_node_in_cluster
+ *
+ * gendersllnl_ion clusterlist module node_in_cluster function
+ */
+static int
+gendersllnl_ion_clusterlist_node_in_cluster(const char *node)
+{
+  char nodebuf[CEREBRO_MAX_NODENAME_LEN+1];
+  char *nodePtr = NULL;
+  int flag;
+
+  if (!gh)
+    {
+      CEREBRO_DBG(("gh null"));
+      return -1;
+    }
+
+  if (!node)
+    {
+      CEREBRO_DBG(("invalid parameters"));
+      return -1;
+    }
+
+  /* Shorten hostname if necessary */
+  if (strchr(node, '.'))
+    {
+      char *p;
+
+      memset(nodebuf, '\0', CEREBRO_MAX_NODENAME_LEN+1);
+      strncpy(nodebuf, node, CEREBRO_MAX_NODENAME_LEN);
+      p = strchr(nodebuf, '.');
+      *p = '\0';
+      nodePtr = nodebuf;
+    }
+  else
+    nodePtr = (char *)node;
+
+  if ((flag = genders_isnode_or_altnode(gh, nodePtr)) < 0)
+    {
+      CEREBRO_ERR(("genders_isnode_or_altnode: %s", genders_errormsg(gh)));
+      return -1;
+    }
+  
+  return flag;
+}
+
+/*
+ * gendersllnl_ion_clusterlist_get_nodename
+ *
+ * gendersllnl_ion clusterlist module get_nodename function
+ */
+static int
+gendersllnl_ion_clusterlist_get_nodename(const char *node, 
+                                         char *buf, 
+                                         unsigned int buflen)
+{
+  char nodebuf[CEREBRO_MAX_NODENAME_LEN+1];
+  char *nodePtr = NULL;
+  int rv;
+
+  if (!gh)
+    {
+      CEREBRO_DBG(("gh null"));
+      return -1;
+    }
+
+  if (!node || !buf || !buflen)
+    {
+      CEREBRO_DBG(("invalid parameters"));
+      return -1;
+    }
+
+  /* Shorten hostname if necessary */
+  if (strchr(node, '.'))
+    {
+      char *p;
+
+      memset(nodebuf, '\0', CEREBRO_MAX_NODENAME_LEN+1);
+      strncpy(nodebuf, node, CEREBRO_MAX_NODENAME_LEN);
+      p = strchr(nodebuf, '.');
+      *p = '\0';
+      nodePtr = nodebuf;
+    }
+  else
+    nodePtr = (char *)node;
+
+  if ((rv = gendersllnl_ion_clusterlist_node_in_cluster(nodePtr)) < 0)
+    return -1;
+
+  if (!rv)
+    {
+      return cerebro_copy_nodename(nodePtr, buf, buflen);
+    }
+  else
+    {
+      if (genders_to_gendname(gh, nodePtr, buf, buflen) < 0)
+	{
+	  CEREBRO_ERR(("genders_to_gendname: %s", genders_errormsg(gh)));
+	  return -1;
+	}
+    }
+
+  return 0;
+}
+
+#if WITH_STATIC_MODULES
+struct cerebro_clusterlist_module_info gendersllnl_ion_clusterlist_module_info =
+#else  /* !WITH_STATIC_MODULES */
+struct cerebro_clusterlist_module_info clusterlist_module_info =
+#endif /* !WITH_STATIC_MODULES */
+  {
+    GENDERSLLNL_ION_CLUSTERLIST_MODULE_NAME,
+    &gendersllnl_ion_clusterlist_interface_version,
+    &gendersllnl_ion_clusterlist_setup,
+    &gendersllnl_ion_clusterlist_cleanup,
+    &gendersllnl_ion_clusterlist_numnodes,
+    &gendersllnl_ion_clusterlist_get_all_nodes,
+    &gendersllnl_ion_clusterlist_node_in_cluster,
+    &gendersllnl_ion_clusterlist_get_nodename,
+  };

--- a/src/modules/clusterlist/cerebro_clusterlist_gendersllnl_ion.c
+++ b/src/modules/clusterlist/cerebro_clusterlist_gendersllnl_ion.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_clusterlist_gendersllnl_ion.c,v 1.4 2007/02/09 00:59:20 achu Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/clusterlist/cerebro_clusterlist_hostsfile.c
+++ b/src/modules/clusterlist/cerebro_clusterlist_hostsfile.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_clusterlist_hostsfile.c,v 1.40 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/clusterlist/cerebro_clusterlist_util.c
+++ b/src/modules/clusterlist/cerebro_clusterlist_util.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_clusterlist_util.c,v 1.20 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/clusterlist/cerebro_clusterlist_util.h
+++ b/src/modules/clusterlist/cerebro_clusterlist_util.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_clusterlist_util.h,v 1.12 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/event/cerebro_event_updown.c
+++ b/src/modules/event/cerebro_event_updown.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_event_updown.c,v 1.8 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_boottime.c
+++ b/src/modules/metric/cerebro_metric_boottime.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_boottime.c,v 1.31 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_bytesin.c
+++ b/src/modules/metric/cerebro_metric_bytesin.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_bytesin.c,v 1.13 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_bytesout.c
+++ b/src/modules/metric/cerebro_metric_bytesout.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_bytesout.c,v 1.13 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_common.c
+++ b/src/modules/metric/cerebro_metric_common.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_common.c,v 1.9 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_common.h
+++ b/src/modules/metric/cerebro_metric_common.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_common.h,v 1.9 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_loadavg.c
+++ b/src/modules/metric/cerebro_metric_loadavg.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_loadavg.c,v 1.10 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_loadavg.h
+++ b/src/modules/metric/cerebro_metric_loadavg.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_loadavg.h,v 1.6 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_loadavg1.c
+++ b/src/modules/metric/cerebro_metric_loadavg1.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_loadavg1.c,v 1.15 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_loadavg15.c
+++ b/src/modules/metric/cerebro_metric_loadavg15.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_loadavg15.c,v 1.15 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_loadavg5.c
+++ b/src/modules/metric/cerebro_metric_loadavg5.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_loadavg5.c,v 1.15 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_memfree.c
+++ b/src/modules/metric/cerebro_metric_memfree.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_memfree.c,v 1.14 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_memory.c
+++ b/src/modules/metric/cerebro_metric_memory.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_memory.c,v 1.13 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_memory.h
+++ b/src/modules/metric/cerebro_metric_memory.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_memory.h,v 1.6 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_memtotal.c
+++ b/src/modules/metric/cerebro_metric_memtotal.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_memtotal.c,v 1.14 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_memused.c
+++ b/src/modules/metric/cerebro_metric_memused.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_memused.c,v 1.14 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_network.c
+++ b/src/modules/metric/cerebro_metric_network.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_network.c,v 1.8 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_network.h
+++ b/src/modules/metric/cerebro_metric_network.h
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_network.h,v 1.6 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_packetsin.c
+++ b/src/modules/metric/cerebro_metric_packetsin.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_packetsin.c,v 1.13 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_packetsout.c
+++ b/src/modules/metric/cerebro_metric_packetsout.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_packetsout.c,v 1.13 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_rxerrs.c
+++ b/src/modules/metric/cerebro_metric_rxerrs.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_rxerrs.c,v 1.13 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_shutdown.c
+++ b/src/modules/metric/cerebro_metric_shutdown.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_shutdown.c,v 1.13 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_slurm_state.c
+++ b/src/modules/metric/cerebro_metric_slurm_state.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_slurm_state.c,v 1.30 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_swapfree.c
+++ b/src/modules/metric/cerebro_metric_swapfree.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_swapfree.c,v 1.15 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_swaptotal.c
+++ b/src/modules/metric/cerebro_metric_swaptotal.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_swaptotal.c,v 1.15 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_swapused.c
+++ b/src/modules/metric/cerebro_metric_swapused.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_swapused.c,v 1.14 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.

--- a/src/modules/metric/cerebro_metric_txerrs.c
+++ b/src/modules/metric/cerebro_metric_txerrs.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
  *  $Id: cerebro_metric_txerrs.c,v 1.13 2010-02-02 01:01:21 chu11 Exp $
  *****************************************************************************
- *  Copyright (C) 2007-2015 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007-2018 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2005-2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Albert Chu <chu11@llnl.gov>.


### PR DESCRIPTION
philosophy : start / stop / restart actions during install or upgrade will force some state at the end of the installation.  The user knows better what he/she needs coming in and going out from install or upgrade.  No starts / stops / restarts is the only way to give the user maximum choice.