### PR TITLE
cerebrod: support --foreground option

### DIFF
--- a/etc/cerebrod.service
+++ b/etc/cerebrod.service
@@ -3,8 +3,8 @@ Description=Cerebrod daemon
 After=syslog.target network.target   
                                       
 [Service]                            
-Type=forking                         
-ExecStart=/usr/sbin/cerebrod         
+Type=simple
+ExecStart=/usr/sbin/cerebrod -f
 ExecReload=/bin/kill -HUP $MAINPID   
 KillMode=process                     
 User=root

--- a/man/cerebrod.8.in
+++ b/man/cerebrod.8.in
@@ -75,8 +75,11 @@ Output version
 .B  -c, --config-file
 Specify alternate configuration file
 .TP
+.B  -f, --foreground
+Run daemon in foreground
+.TP
 .B  -d, --debug
-Turn on debugging and run daemon in foreground
+Turn on debugging, implies --foreground
 
 .SH "FILES"
 @CEREBRO_CONFIG_FILE_DEFAULT@

--- a/src/cerebrod/cerebrod.c
+++ b/src/cerebrod/cerebrod.c
@@ -112,11 +112,12 @@ main(int argc, char **argv)
 
   cerebrod_config_setup(argc, argv);
 
+
+  if (!conf.foreground)
+    cerebrod_daemon_init();
+
   if (!conf.debug)
-    {
-      cerebrod_daemon_init();
-      cerebro_err_set_flags(CEREBRO_ERROR_SYSLOG);
-    }
+    cerebro_err_set_flags(CEREBRO_ERROR_SYSLOG);
   else
     cerebro_err_set_flags(CEREBRO_ERROR_STDERR);
 

--- a/src/cerebrod/cerebrod_config.c
+++ b/src/cerebrod/cerebrod_config.c
@@ -91,6 +91,7 @@ _cerebrod_set_config_default(void)
   memset(&conf, '\0', sizeof(struct cerebrod_config));
 
   conf.debug = CEREBROD_DEBUG_DEFAULT;
+  conf.foreground = CEREBROD_FOREGROUND_DEFAULT;
   conf.config_file = CEREBRO_CONFIG_FILE_DEFAULT;
 
   conf.heartbeat_frequency_min = CEREBROD_HEARTBEAT_FREQUENCY_MIN_DEFAULT;
@@ -153,8 +154,8 @@ _usage(void)
           "-h    --help          Output Help\n"
           "-v    --version       Output Version\n"
           "-c    --config_file   Specify alternate config file\n"
-          "-d    --debug         Turn on debugging and run daemon\n"
-          "                      in foreground\n");
+          "-f    --foreground    run in foreground\n"
+          "-d    --debug         Turn on debugging and run daemon, implies --foreground\n");
   exit(0);
 }
 
@@ -188,13 +189,14 @@ _cerebrod_cmdline_arguments_parse(int argc, char **argv)
       {"version",             0, NULL, 'v'},
       {"config-file",         1, NULL, 'c'},
       {"debug",               0, NULL, 'd'},
+      {"foreground",          0, NULL, 'f'},
     };
 #endif /* HAVE_GETOPT_LONG */
 
   assert(argv);
 
   memset(options, '\0', sizeof(options));
-  strcat(options, "hvc:d");
+  strcat(options, "hvc:df");
 
   /* turn off output messages */
   opterr = 0;
@@ -216,7 +218,11 @@ _cerebrod_cmdline_arguments_parse(int argc, char **argv)
         case 'c':       /* --config-file */
           conf.config_file = Strdup(optarg);
           break;
+        case 'f':       /* --foreground */
+          conf.foreground++;
+          break;
         case 'd':       /* --debug */
+          conf.foreground++;
           conf.debug++;
           break;
         case '?':
@@ -1155,6 +1161,7 @@ _cerebrod_config_dump(void)
   fprintf(stderr, "* Command Line Options\n");
   fprintf(stderr, "* -------------------------------\n");
   fprintf(stderr, "* debug: %d\n", conf.debug);
+  fprintf(stderr, "* foreground: %d\n", conf.foreground);
   fprintf(stderr, "* config_file: \"%s\"\n", conf.config_file);
   fprintf(stderr, "* -------------------------------\n");
   fprintf(stderr, "* Configuration File Options\n");

--- a/src/cerebrod/cerebrod_config.h
+++ b/src/cerebrod/cerebrod_config.h
@@ -41,6 +41,7 @@
 #include "hostlist.h"
 
 #define CEREBROD_DEBUG_DEFAULT                                    0
+#define CEREBROD_FOREGROUND_DEFAULT                               0
 #define CEREBROD_HEARTBEAT_FREQUENCY_MIN_DEFAULT                  10
 #define CEREBROD_HEARTBEAT_FREQUENCY_MAX_DEFAULT                  20
 #define CEREBROD_SPEAK_DEFAULT                                    1
@@ -125,6 +126,7 @@ struct cerebrod_config
 {
   /* Set by the user on the command line */
   int debug;
+  int foreground;
   char *config_file;
 
   /* Set by the user in the configuration file */


### PR DESCRIPTION
Problem: Systemd can "daemonize" a process, and in many cases it is preferred versus doing it within the daemon.

Support a --foreground option and update systemd to launch cerebrod via "simple".